### PR TITLE
[#24] Restrict release deploys to local release tags

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,7 +2,9 @@ name: Release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+"
+      - "[0-9]*.[0-9]*.[0-9]*"
+      - "v*"
+      - "release-*"
 
 env:
   REGISTRY: ghcr.io
@@ -202,6 +204,7 @@ jobs:
   deploy:
     needs: [verify, prepare]
     runs-on: ubuntu-latest
+    if: github.ref_type == 'tag' && endsWith(github.ref_name, '-local-release')
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- Update the release workflow tag triggers to include `v*`, `release-*`, and numeric release tags.
- Restrict the `deploy` job to tag refs ending with `-local-release`.
- Keep non-local release tags building/releasing while skipping deployment.

## Related

Closes #24