### PR TITLE
[#23] Resolve OpenGrep security findings

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -12,6 +12,8 @@ env:
   TRIVY_VERSION: "v0.67.2"
   TRIVY_SEVERITY: "CRITICAL,HIGH,MEDIUM,LOW"
   OPENGREP_VERSION: "v1.11.2"
+  # SQLAlchemy/SQLAdmin mapped attributes are descriptors, not missed function calls.
+  OPENGREP_SQLALCHEMY_FALSE_POSITIVE_RULE: "opengrep-rules.python.lang.maintainability.is-function-without-parentheses"
   TRUFFLEHOG_VERSION: "v3.90.12"
   GITLEAKS_VERSION: "v8.28.0"
 
@@ -184,7 +186,12 @@ jobs:
       - name: Run Opengrep Scan (report)
         run: |
           export PATH='/home/runner/.opengrep/cli/latest':$PATH
-          opengrep scan --config opengrep-rules/python --json -o "${{ runner.workspace }}/opengrep-results.json" .
+          opengrep scan \
+            --config opengrep-rules/python \
+            --exclude-rule "${OPENGREP_SQLALCHEMY_FALSE_POSITIVE_RULE}" \
+            --json \
+            -o "${{ runner.workspace }}/opengrep-results.json" \
+            .
 
       - name: Upload scan results
         uses: actions/upload-artifact@v4
@@ -196,4 +203,8 @@ jobs:
       - name: Run Opengrep Scan (alert)
         run: |
           export PATH='/home/runner/.opengrep/cli/latest':$PATH
-          opengrep scan --config opengrep-rules/python --error .
+          opengrep scan \
+            --config opengrep-rules/python \
+            --exclude-rule "${OPENGREP_SQLALCHEMY_FALSE_POSITIVE_RULE}" \
+            --error \
+            .

--- a/src/db/clickhouse.py
+++ b/src/db/clickhouse.py
@@ -91,7 +91,7 @@ class AsyncClickHouseConnectors:
                     connect_timeout=self._clickhouse_settings.timeout,
                 )
             except Exception as e:
-                logger.error("[CH] Failed to create client: %r", e)
+                logger.warning("[CH] Failed to create client: %r", e)
                 raise RuntimeError(f"ClickHouse: Failed to create client: {e}") from e
 
         await self._ping_connection()
@@ -143,7 +143,7 @@ class AsyncClickHouseConnectors:
             if result != 1:
                 raise RuntimeError("Unable to ping ClickHouse server")
         except Exception as e:
-            logger.error("[CH] Failed to ping connection to %s: %s", connection_info, e)
+            logger.warning("[CH] Failed to ping connection to %s: %s", connection_info, e)
             raise RuntimeError(f"ClickHouse: Failed to ping connection: {e}") from e
 
         logger.info("[CH] Connection to %s is healthy", connection_info)
@@ -163,7 +163,7 @@ class AsyncClickHouseConnectors:
             logger.debug("[CH] Table %s created or already exists", table_name)
 
         except Exception as e:
-            logger.error("[CH] Failed to create table: %r", e)
+            logger.warning("[CH] Failed to create table: %r", e)
             raise
 
 

--- a/src/db/redis.py
+++ b/src/db/redis.py
@@ -54,7 +54,7 @@ class AsyncRedisConnectors:
                 raise aioredis.ConnectionError("Unable to ping Redis server")
 
         except aioredis.ConnectionError as e:
-            logger.error("Redis: Failed to ping connection to %s: %s", connection_info, e)
+            logger.warning("Redis: Failed to ping connection to %s: %s", connection_info, e)
             raise RuntimeError(f"Redis: Failed to ping connection: {e}") from e
 
     async def close_connection(self) -> None:

--- a/src/db/repositories.py
+++ b/src/db/repositories.py
@@ -154,7 +154,7 @@ class TokenRepository(BaseRepository[Token]):
 
     async def get_by_token(self, hashed_token: str) -> Token | None:
         """Get token by hashed token value"""
-        logger.debug("[DB] Getting token by hash: %s", hashed_token)
+        logger.debug("[DB] Getting token by hash")
         filtered_tokens = await self.all(token=hashed_token)
         if not filtered_tokens:
             return None

--- a/src/db/services.py
+++ b/src/db/services.py
@@ -110,7 +110,7 @@ class SASessionUOW:
                 # Don't close session - dependency will handle it
 
         except Exception as exc:
-            logger.error("[DB] Error during UOW cleanup: %r", exc)
+            logger.warning("[DB] Error during UOW cleanup: %r", exc)
             if self.__owns_session:
                 await self.__session.close()
 
@@ -129,7 +129,7 @@ class SASessionUOW:
             self.__need_to_commit = False
             logger.debug("[DB] Transaction committed successfully")
         except Exception as exc:
-            logger.error("[DB] Failed to commit transaction", exc_info=exc)
+            logger.warning("[DB] Failed to commit transaction", exc_info=exc)
             await self.rollback()
             raise exc
 
@@ -141,7 +141,7 @@ class SASessionUOW:
             self.__need_to_commit = False
             logger.debug("[DB] Transaction rolled back successfully")
         except Exception as exc:
-            logger.error("[DB] Failed to rollback transaction", exc_info=exc)
+            logger.warning("[DB] Failed to rollback transaction", exc_info=exc)
             raise exc
 
     @property

--- a/src/db/session.py
+++ b/src/db/session.py
@@ -57,7 +57,7 @@ class AsyncDBConnectors:
             logger.info("[DB] Database engine and session factory initialized successfully")
 
         except Exception as e:
-            logger.error("[DB] Failed to initialize database: %r", e)
+            logger.warning("[DB] Failed to initialize database: %r", e)
             await self.close_connection()
             raise
 
@@ -65,15 +65,15 @@ class AsyncDBConnectors:
         """Try to acquire a connection and execute a simple query to ensure DB is alive"""
         logger.info("[DB] Pinging connection to database...")
         if not self.engine:
-            logger.error("[DB] Engine is not initialized, cannot ping database")
+            logger.warning("[DB] Engine is not initialized, cannot ping database")
             raise RuntimeError("Engine is not initialized, cannot ping database")
 
         try:
             async with self.engine.connect() as conn:
-                await conn.execute(sa.text("SELECT 1"))
+                await conn.execute(sa.select(sa.literal(1)))
 
         except Exception as exc:
-            logger.error("[DB] Failed to ping database: %r", exc)
+            logger.warning("[DB] Failed to ping database: %r", exc)
             self.exc = exc
             raise DatabaseError("Failed to ping database") from exc
 
@@ -98,7 +98,7 @@ class AsyncDBConnectors:
                 logger.info("[DB] Database engine closed successfully")
 
         except Exception as exc:
-            logger.error("[DB] Failed to close database connection: %r", exc)
+            logger.warning("[DB] Failed to close database connection: %r", exc)
             raise
 
 

--- a/src/modules/admin/auth.py
+++ b/src/modules/admin/auth.py
@@ -56,8 +56,7 @@ class AdminAuth(AuthenticationBackend):
         return True
 
     async def authenticate(self, request: Request) -> bool:
-        token = request.session.get("token")
-
+        token: str | None = request.session.get("token")
         if not token:
             return False
 

--- a/src/modules/admin/views/releases.py
+++ b/src/modules/admin/views/releases.py
@@ -56,6 +56,10 @@ def _make_date_formatter(column_name: str) -> Any:
     return formatter
 
 
+def _format_release_details_link(model: Any, _: Any) -> str:
+    return admin_get_link(cast(BaseModel, model), target="details")
+
+
 def _invalidate_releases(func: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator to invalidate releases cache after the function is called"""
 
@@ -76,7 +80,12 @@ class ReleaseAdminView(BaseModelView, model=Release):
     create_template = "releases/release_create.html"
     edit_template = "releases/release_edit.html"
     details_template = "releases/release_details.html"
-    column_list = (Release.id, Release.version, Release.published_at, Release.is_active)
+    column_list = (
+        Release.id,
+        Release.version,
+        Release.published_at,
+        Release.is_active,
+    )
     form_columns = (
         Release.version,
         Release.published_at,
@@ -92,7 +101,7 @@ class ReleaseAdminView(BaseModelView, model=Release):
         Release.updated_at: "Изменен",
     }
     column_formatters = {
-        Release.id: lambda model, a: admin_get_link(cast(BaseModel, model), target="details"),
+        Release.id: _format_release_details_link,
         Release.published_at: _make_date_formatter("published_at"),
         Release.created_at: _make_datetime_formatter("created_at"),
         Release.updated_at: _make_datetime_formatter("updated_at"),

--- a/src/modules/admin/views/tokens.py
+++ b/src/modules/admin/views/tokens.py
@@ -1,6 +1,6 @@
 import logging
 import datetime
-from typing import cast
+from typing import Any, cast
 
 from sqladmin import action
 from starlette.datastructures import URL
@@ -19,16 +19,23 @@ __all__ = ("TokenAdminView",)
 logger = logging.getLogger(__name__)
 
 
+def _format_token_details_link(model: Any, _: Any) -> str:
+    return admin_get_link(cast(BaseModel, model), target="details")
+
+
 class TokenAdminView(BaseModelView, model=Token):
     name = "API Token"
     name_plural = "API Tokens"
     icon = "fa-solid fa-key"
-    column_list = (Token.id, Token.user, Token.is_active, Token.expires_at)
+    column_list = (
+        Token.id,
+        Token.user,
+        Token.is_active,
+        Token.expires_at,
+    )
     form_columns = (Token.user, Token.name, Token.expires_at)
     can_edit = False
-    column_formatters = {
-        Token.id: lambda model, a: admin_get_link(cast(BaseModel, model), target="details")
-    }
+    column_formatters = {Token.id: _format_token_details_link}
     column_details_list = (
         Token.id,
         Token.user,

--- a/src/modules/admin/views/users.py
+++ b/src/modules/admin/views/users.py
@@ -15,6 +15,10 @@ __all__ = ("UserAdminView",)
 logger = logging.getLogger(__name__)
 
 
+def _format_user_link(model: Any, _: Any) -> str:
+    return admin_get_link(cast(BaseModel, model))
+
+
 class UserAdminForm(Form):
     """Provides extra validation for users' creation/updating"""
 
@@ -44,9 +48,13 @@ class UserAdminView(BaseModelView, model=User):
 
     form = UserAdminForm
     icon = "fa-solid fa-person-drowning"
-    column_list = (User.id, User.username, User.is_active)
+    column_list = (
+        User.id,
+        User.username,
+        User.is_active,
+    )
     column_details_list = (User.id, User.username, User.email)
-    column_formatters = {User.username: lambda model, a: admin_get_link(cast(BaseModel, model))}
+    column_formatters = {User.username: _format_user_link}
 
     async def insert_model(self, request: Request, data: FormDataType) -> Any:
         """Create a new user and insert it into the database"""

--- a/src/modules/auth/tokens.py
+++ b/src/modules/auth/tokens.py
@@ -21,8 +21,6 @@ __all__ = (
     "verify_api_token",
 )
 
-from src.utils import cut_string
-
 type JWT_PAYLOAD_RAW_T = dict[str, str | int | datetime.datetime]
 
 
@@ -104,13 +102,7 @@ def make_api_token(
     )
     _, payload_part, signature_part = encrypted_token.split(".")
     sign_len_prefix = f"{len(signature_part):0>3}"
-    logger.debug(
-        "[auth] Generated token: id: '%s' | len_prefix: '%s' | payload: '%s' | signature: '%s'",
-        token_identifier,
-        sign_len_prefix,
-        payload_part,
-        signature_part,
-    )
+    logger.debug("[auth] Generated API token with signature length %s", sign_len_prefix)
     result_value = f"{payload_part}{signature_part}{sign_len_prefix}"
 
     return GeneratedToken(value=result_value, hashed_value=hash_token(token_identifier))
@@ -135,7 +127,7 @@ def decode_api_token(token: str, settings: SettingsDep) -> JWTPayload:
     Returns:
         PayloadTokenInfo - payload of the token
     """
-    logger.debug("[auth] Decoding token: '%s'", token)
+    logger.debug("[auth] Decoding API token with length %s", len(token))
     just_for_header_token = jwt_encode(payload=JWTPayload(sub="example"), settings=settings)
     header_part, _, _ = just_for_header_token.split(".")
     token, sign_len_prefix = token[:-3], token[-3:]  # last 3 symbols contain len of signature
@@ -147,7 +139,7 @@ def decode_api_token(token: str, settings: SettingsDep) -> JWTPayload:
     payload_part, signature_part = token[:-signature_length], token[-signature_length:]
 
     checking_token = f"{header_part}.{payload_part}.{signature_part}"
-    logger.debug("[auth] JWT decoding token: %s", checking_token)
+    logger.debug("[auth] Decoding JWT payload with signature length %s", signature_length)
 
     try:
         payload = jwt_decode(checking_token, settings=settings)
@@ -190,7 +182,7 @@ async def verify_api_token(
     if not auth_token:
         raise HTTPException(status_code=401, detail="Not authenticated")
 
-    logger.info("[auth] Authentication: input auth token: '%s'", cut_string(auth_token, 15))
+    logger.info("[auth] Authentication: API token received")
 
     decoded_payload = decode_api_token(auth_token, settings=settings)
     raw_token_identity = decoded_payload.sub
@@ -202,9 +194,10 @@ async def verify_api_token(
     async with SASessionUOW() as uow:
         token = await TokenRepository(session=uow.session).get_by_token(hashed_token)
 
-    logger.info("[auth] Verification: token extracted '%s'", token)
     if not token:
         raise HTTPException(status_code=401, detail="Not authenticated: unknown token")
+
+    logger.info("[auth] Verification: matching token record extracted")
 
     if not token.is_active:
         raise HTTPException(status_code=401, detail="Not authenticated: inactive token")

--- a/src/services/cache.py
+++ b/src/services/cache.py
@@ -52,11 +52,11 @@ def cache_wrap_error(
     try:
         yield
     except aioredis.RedisError as exc:
-        logger.error("Cache[%s:%s] execution error: %s", backend, operation, exc)
+        logger.warning("Cache[%s:%s] execution error: %s", backend, operation, exc)
         raise CacheBackendError(f"Redis execution error: {exc}") from exc
 
     except (TypeError, ValueError) as exc:
-        logger.error("Cache[%s:%s] common error: %s", backend, operation, exc)
+        logger.warning("Cache[%s:%s] common error: %s", backend, operation, exc)
         raise CacheBackendError(f"Common error: {exc}") from exc
 
 

--- a/src/settings/app.py
+++ b/src/settings/app.py
@@ -37,9 +37,9 @@ class AdminSettings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="ADMIN_")
 
-    username: str = Field(default_factory=lambda: "admin", description="Default admin username")
+    username: str = Field(default="admin", description="Default admin username")
     password: SecretStr = Field(
-        default_factory=lambda: SecretStr("release-admin!"),
+        default=SecretStr("release-admin!"),
         description="Default admin password",
     )
     session_expiration_time: int = 2 * 24 * 3600

--- a/src/settings/db.py
+++ b/src/settings/db.py
@@ -19,8 +19,8 @@ class DBSettings(BaseSettings):
     user: str = "postgres"
     password: str = "postgres"
     name: str = "release_agent"
-    pool_min_size: int | None = Field(default_factory=lambda: None, description="Pool Min Size")
-    pool_max_size: int | None = Field(default_factory=lambda: None, description="Pool Max Size")
+    pool_min_size: int | None = Field(default=None, description="Pool Min Size")
+    pool_max_size: int | None = Field(default=None, description="Pool Max Size")
     echo: bool = False
 
     @cached_property

--- a/src/tests/units/auth/test_auth_tokens.py
+++ b/src/tests/units/auth/test_auth_tokens.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import pytest
 from unittest.mock import MagicMock, AsyncMock
 from starlette.exceptions import HTTPException
@@ -105,6 +106,15 @@ class TestMakeAPIToken:
         # Token should be longer than just the length prefix
         assert len(result.value) > 3
 
+    def test_make_api_token_does_not_log_token_value(
+        self, app_settings_test: AppSettings, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        with caplog.at_level(logging.DEBUG):
+            result = make_api_token(expires_at=None, settings=app_settings_test)
+
+        assert result.value not in caplog.text
+        assert result.hashed_value not in caplog.text
+
 
 class TestDecodeAPIToken:
 
@@ -143,6 +153,16 @@ class TestDecodeAPIToken:
 
         assert exc_info.value.status_code == 401
         assert "Invalid token" in str(exc_info.value.detail)
+
+    def test_decode_api_token_does_not_log_token_value(
+        self, app_settings_test: AppSettings, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        generated = make_api_token(expires_at=None, settings=app_settings_test)
+
+        with caplog.at_level(logging.DEBUG):
+            decode_api_token(generated.value, app_settings_test)
+
+        assert generated.value not in caplog.text
 
 
 class TestHashToken:

--- a/src/tests/units/test_repositories.py
+++ b/src/tests/units/test_repositories.py
@@ -274,7 +274,7 @@ class TestTokenRepository:
 
             assert result == mock_token
             token_repo.all.assert_awaited_once_with(token="hashed_token_value")
-            mock_logger.debug.assert_called_once()
+            mock_logger.debug.assert_called_once_with("[DB] Getting token by hash")
 
     @pytest.mark.asyncio
     async def test_get_by_token_not_found(self, token_repo: TokenRepository) -> None:
@@ -286,7 +286,7 @@ class TestTokenRepository:
 
             assert result is None
             token_repo.all.assert_awaited_once_with(token="nonexistent")
-            mock_logger.debug.assert_called_once()
+            mock_logger.debug.assert_called_once_with("[DB] Getting token by hash")
 
     @pytest.mark.asyncio
     async def test_set_active_true(self, token_repo: TokenRepository) -> None:

--- a/src/tests/units/test_services.py
+++ b/src/tests/units/test_services.py
@@ -200,13 +200,13 @@ class TestSASessionUOW:
         with pytest.raises(Exception, match="Flush failed"):
             await uow.__aexit__(None, None, None)
 
-        # Verify error logging and session close
-        error_calls = [
+        # Verify warning logging and session close
+        warning_calls = [
             call
-            for call in mock_logger.error.call_args_list
+            for call in mock_logger.warning.call_args_list
             if call[0][0] == "[DB] Error during UOW cleanup: %r"
         ]
-        assert len(error_calls) > 0
+        assert len(warning_calls) > 0
         mock_db_session.close.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -243,12 +243,12 @@ class TestSASessionUOW:
 
         # Verify rollback was called
         mock_db_session.rollback.assert_awaited_once()
-        error_calls = [
+        warning_calls = [
             call
-            for call in mock_logger.error.call_args_list
+            for call in mock_logger.warning.call_args_list
             if call[0][0] == "[DB] Failed to commit transaction"
         ]
-        assert len(error_calls) > 0
+        assert len(warning_calls) > 0
 
     @pytest.mark.asyncio
     async def test_rollback_success(
@@ -281,12 +281,12 @@ class TestSASessionUOW:
         with pytest.raises(Exception, match="Rollback failed"):
             await uow.rollback()
 
-        error_calls = [
+        warning_calls = [
             call
-            for call in mock_logger.error.call_args_list
+            for call in mock_logger.warning.call_args_list
             if call[0][0] == "[DB] Failed to rollback transaction"
         ]
-        assert len(error_calls) > 0
+        assert len(warning_calls) > 0
 
     def test_need_to_commit_property(self) -> None:
         uow = SASessionUOW(session=AsyncMock(spec=AsyncSession))

--- a/src/tests/units/test_session.py
+++ b/src/tests/units/test_session.py
@@ -120,8 +120,8 @@ class TestAsyncDBConnectors:
                     # Verify close_connection was called
                     connectors.close_connection.assert_awaited_once()
 
-                    # Verify error logging
-                    mock_logger.error.assert_called_with(
+                    # Verify warning logging
+                    mock_logger.warning.assert_called_with(
                         "[DB] Failed to initialize database: %r", test_exception
                     )
 

--- a/src/tests/units/test_utils.py
+++ b/src/tests/units/test_utils.py
@@ -1,4 +1,4 @@
-from src.utils import singleton
+from src.utils import admin_get_link, singleton
 
 
 class TestSingleton:
@@ -39,6 +39,21 @@ class TestSingleton:
         assert instance2.modified is True
 
         instance2.value = ""
+
+
+class TestAdminGetLink:
+    def test_escapes_model_string(self) -> None:
+        class DangerousModel:
+            id = 7
+
+            def __str__(self) -> str:
+                return '<script>alert("x")</script>'
+
+        result = str(admin_get_link(DangerousModel()))  # type: ignore[arg-type]
+
+        assert '<script>alert("x")</script>' not in result
+        assert "&lt;script&gt;alert(&#34;x&#34;)&lt;/script&gt;" in result
+        assert 'href="/radm/dangerousmodel/edit/7"' in result
 
     def test_multiple_singleton_classes(self) -> None:
         @singleton

--- a/src/utils.py
+++ b/src/utils.py
@@ -117,9 +117,9 @@ def admin_get_link(
     settings = get_app_settings()
     base_url = settings.admin.base_url
     name = url_name or instance.__class__.__name__.lower()
-    return markupsafe.Markup(
-        f'<a href="{base_url}/{name}/{target}/{instance.id}">[#{instance.id}] {instance}</a>'
-    )
+    href = f"{base_url}/{name}/{target}/{instance.id}"
+    label = f"[#{instance.id}] {instance}"
+    return markupsafe.Markup('<a href="{href}">{label}</a>').format(href=href, label=label)
 
 
 def simple_slugify(value: str) -> str:


### PR DESCRIPTION
## Summary

- Removed sensitive token/JWT/hash values from auth and repository logs.
- Escaped SQLAdmin link labels generated via `Markup`.
- Replaced raw SQL ping text with SQLAlchemy expression usage.
- Downgraded re-raised exception logs from error to warning.
- Added a centralized OpenGrep exclusion for the noisy SQLAlchemy/SQLAdmin descriptor rule.

## Related

Closes #23
